### PR TITLE
Review usage of radius of Earth

### DIFF
--- a/earthkit/geo/__init__.py
+++ b/earthkit/geo/__init__.py
@@ -22,11 +22,14 @@ from earthkit.geo.distance import (
     nearest_point_haversine,
     nearest_point_kdtree,
 )
+from earthkit.geo.figure import IFS_SPHERE, UNIT_SPHERE
 
 __all__ = [
     "GeoKDTree",
     "haversine_distance",
+    IFS_SPHERE,
     "nearest_point_haversine",
     "nearest_point_kdtree",
+    UNIT_SPHERE,
     "__version__",
 ]

--- a/earthkit/geo/constants.py
+++ b/earthkit/geo/constants.py
@@ -15,11 +15,5 @@ R_earth = 6371229
 r"""Average radius of the Earth [:math:`m`]. See [IFS-CY47R3-PhysicalProcesses]_
  (Chapter 12)."""
 
-full_circle = 360
-r"""Full circle in degrees"""
-
 north = 90
 r"""Latitude of the north pole in degrees"""
-
-south = -90
-r"""Latitude of the south pole in degrees"""

--- a/earthkit/geo/constants.py
+++ b/earthkit/geo/constants.py
@@ -11,9 +11,5 @@
 Collection of constants in SI units.
 """
 
-R_earth = 6371229
-r"""Average radius of the Earth [:math:`m`]. See [IFS-CY47R3-PhysicalProcesses]_
- (Chapter 12)."""
-
 north = 90
 r"""Latitude of the north pole in degrees"""

--- a/earthkit/geo/distance.py
+++ b/earthkit/geo/distance.py
@@ -10,14 +10,15 @@
 import numpy as np
 
 from . import constants
+from .figure import IFS_SPHERE, UNIT_SPHERE
 
 
 def _regulate_lat(lat):
     return np.where(np.abs(lat) > constants.north, np.nan, lat)
 
 
-def haversine_distance(p1, p2, radius=constants.R_earth):
-    """Compute haversine distance between two (sets of) points on a sphere.
+def haversine_distance(p1, p2, figure=IFS_SPHERE):
+    """Compute haversine distance between two (sets of) points on a spheroid.
 
     Parameters
     ----------
@@ -27,13 +28,13 @@ def haversine_distance(p1, p2, radius=constants.R_earth):
     p2: pair of array-like
         Locations of the second points. The first item specifies the latitudes,
         the second the longitudes (degrees)
-    radius: float, optional
-        Radius of the sphere (default: Earth's radius in meters)
+    figure: :class:`geo.figure.Figure`, optional
+        Figure of the spheroid (default: :obj:`geo.figure.IFS_SPHERE`)
 
     Returns
     -------
     number or ndarray
-        Spherical distance on the surface of the sphere (m)
+        Distance (m) on the surface of the spheroid defined by ``figure``.
 
 
     Either ``p1`` or ``p2`` must be a single point.
@@ -88,13 +89,10 @@ def haversine_distance(p1, p2, radius=constants.R_earth):
     )
     distance = 2 * np.arcsin(a)
 
-    if radius == 1:
-        return distance
-    else:
-        return radius * distance
+    return figure.scale(distance)
 
 
-def nearest_point_haversine(ref_points, points, radius=constants.R_earth):
+def nearest_point_haversine(ref_points, points, figure=IFS_SPHERE):
     """Find the index of the nearest point to all ``ref_points`` in a set of
       ``points`` using the haversine distance formula.
 
@@ -106,9 +104,9 @@ def nearest_point_haversine(ref_points, points, radius=constants.R_earth):
         Locations of the set of points from which the nearest to
         ``ref_points`` is to be found. The first item specifies the latitudes,
         the second the longitudes (degrees)
-    radius: float, optional
-        Radius of the sphere (default: Earth's radius in meters) the returned
-        distances are computed on
+    figure: :class:`geo.figure.Figure`, optional
+        Figure of the spheroid the returned
+        distances are computed on (default: :obj:`geo.figure.IFS_SPHERE`)
 
     Returns
     -------
@@ -116,7 +114,7 @@ def nearest_point_haversine(ref_points, points, radius=constants.R_earth):
         Indices of the nearest points to ``ref_points``.
     ndarray
         The distance (m) between the ``ref_points`` and the corresponding nearest
-        point in ``points``.
+        point in ``points`` on the surface of the spheroid defined by ``figure``.
 
     Examples
     --------
@@ -146,15 +144,16 @@ def nearest_point_haversine(ref_points, points, radius=constants.R_earth):
     res_index = []
     res_distance = []
     for lat, lon in ref_points.T:
-        distance = haversine_distance((lat, lon), points, radius=1).flatten()
+        distance = haversine_distance((lat, lon), points, figure=UNIT_SPHERE).flatten()
         index = np.nanargmin(distance)
         index = index[0] if isinstance(index, np.ndarray) else index
         res_index.append(index)
         res_distance.append(distance[index])
-    return (np.array(res_index), np.array(res_distance) * radius)
+    return (np.array(res_index), figure.scale(np.array(res_distance)))
 
 
-def _ll_to_xyz(lat, lon, radius=constants.R_earth):
+def _latlon_to_xyz(lat, lon):
+    """Works on the unit sphere."""
     lat = np.asarray(lat)
     lon = np.asarray(lon)
     lat = np.radians(lat)
@@ -163,40 +162,32 @@ def _ll_to_xyz(lat, lon, radius=constants.R_earth):
     y = np.cos(lat) * np.sin(lon)
     z = np.sin(lat)
 
-    if radius == 1:
-        return x, y, z
-    else:
-        return radius * x, radius * y, radius * z
+    return x, y, z
 
 
-def _cordlength_to_arclength(chord_length, radius=constants.R_earth):
+def _cordlength_to_arclength(chord_length):
     """
     Convert 3D (Euclidean) distance to great circle arc length
     https://en.wikipedia.org/wiki/Great-circle_distance
+    Works on the unit sphere.
     """
-    if radius == 1:
-        central_angle = 2.0 * np.arcsin(chord_length / 2.0)
-        return central_angle
-    else:
-        central_angle = 2.0 * np.arcsin(chord_length / (2.0 * radius))
-        return radius * central_angle
+    central_angle = 2.0 * np.arcsin(chord_length / 2.0)
+    return central_angle
 
 
-def _arclength_to_cordlength(arc_length, radius=constants.R_earth):
+def _arclength_to_cordlength(arc_length):
     """
     Convert great circle arc length to 3D (Euclidean) distance
     https://en.wikipedia.org/wiki/Great-circle_distance
+    Works on the unit sphere.
     """
-    if radius == 1:
-        central_angle = arc_length
-        return np.sin(central_angle / 2) * 2.0
-    else:
-        central_angle = arc_length / radius
-        return np.sin(central_angle / 2) * 2.0 * radius
+    central_angle = arc_length
+    return np.sin(central_angle / 2) * 2.0
 
 
 class GeoKDTree:
     def __init__(self, lats, lons):
+        """KDTree built from ``lats`` and ``lons``."""
         from scipy.spatial import KDTree
 
         lats = np.asarray(lats).flatten()
@@ -208,22 +199,40 @@ class GeoKDTree:
             lats = lats[mask]
             lons = lons[mask]
 
-        x, y, z = _ll_to_xyz(lats, lons, radius=1)
+        x, y, z = _latlon_to_xyz(lats, lons)
         v = np.column_stack((x, y, z))
         self.tree = KDTree(v)
 
         # TODO: allow user to specify max distance
         self.max_distance_arc = np.pi / 4
         if self.max_distance_arc <= np.pi:
-            self.max_distance_cord = _arclength_to_cordlength(
-                self.max_distance_arc, radius=1
-            )
+            self.max_distance_cord = _arclength_to_cordlength(self.max_distance_arc)
         else:
             self.max_distance_cord = np.inf
 
-    def nearest_point(self, points, radius=constants.R_earth):
-        lat, lon = points
-        x, y, z = _ll_to_xyz(lat, lon, radius=1)
+    def nearest_point(self, ref_points, figure=IFS_SPHERE):
+        """Find the index of the nearest point to all ``ref_points``.
+
+        Parameters
+        ----------
+        ref_points: pair of array-like
+            Latitude and longitude coordinates of the reference point (degrees)
+        figure: :class:`geo.figure.Figure`, optional
+            Figure of the spheroid the returned
+            distances are computed on (default: :obj:`geo.figure.IFS_SPHERE`)
+
+        Returns
+        -------
+        ndarray
+            Indices of the nearest points to ``ref_points``.
+        ndarray
+            The distance (m) between the ``ref_points`` and the corresponding nearest
+            point in ``points``. Computed on the surface of the spheroid defined
+            by ``figure``.
+
+        """
+        lat, lon = ref_points
+        x, y, z = _latlon_to_xyz(lat, lon)
         points = np.column_stack((x, y, z))
 
         # find the nearest point
@@ -231,10 +240,10 @@ class GeoKDTree:
             points, distance_upper_bound=self.max_distance_arc
         )
 
-        return index, _cordlength_to_arclength(distance, radius=1) * radius
+        return index, figure.scale(_cordlength_to_arclength(distance))
 
 
-def nearest_point_kdtree(ref_points, points, radius=constants.R_earth):
+def nearest_point_kdtree(ref_points, points, figure=IFS_SPHERE):
     """Find the index of the nearest point to all ``ref_points`` in a set of ``points`` using a KDTree.
 
     Parameters
@@ -245,9 +254,9 @@ def nearest_point_kdtree(ref_points, points, radius=constants.R_earth):
         Locations of the set of points from which the nearest to
         ``ref_points`` is to be found. The first item specifies the latitudes,
         the second the longitudes (degrees)
-    radius: float, optional
-        Radius of the sphere (default: Earth's radius in meters) the returned
-        distances are computed on
+    figure: :class:`geo.figure.Figure`, optional
+        Figure of the spheroid the returned
+        distances are computed on (default: :obj:`geo.figure.IFS_SPHERE`)
 
     Returns
     -------
@@ -255,7 +264,8 @@ def nearest_point_kdtree(ref_points, points, radius=constants.R_earth):
         Indices of the nearest points to ``ref_points``.
     ndarray
         The distance (m) between the ``ref_points`` and the corresponding nearest
-        point in ``points``.
+        point in ``points``. Computed on the surface of the spheroid defined
+        by ``figure``.
 
     Examples
     --------
@@ -276,5 +286,5 @@ def nearest_point_kdtree(ref_points, points, radius=constants.R_earth):
     """
     lats, lons = points
     tree = GeoKDTree(lats, lons)
-    index, distance = tree.nearest_point(ref_points, radius=radius)
+    index, distance = tree.nearest_point(ref_points, figure=figure)
     return index, distance

--- a/earthkit/geo/distance.py
+++ b/earthkit/geo/distance.py
@@ -8,7 +8,6 @@
 #
 
 import numpy as np
-from scipy.spatial import KDTree
 
 from . import constants
 
@@ -198,6 +197,8 @@ def _arclength_to_cordlength(arc_length, radius=constants.R_earth):
 
 class GeoKDTree:
     def __init__(self, lats, lons):
+        from scipy.spatial import KDTree
+
         lats = np.asarray(lats).flatten()
         lons = np.asarray(lons).flatten()
 

--- a/earthkit/geo/distance.py
+++ b/earthkit/geo/distance.py
@@ -165,7 +165,7 @@ def _latlon_to_xyz(lat, lon):
     return x, y, z
 
 
-def _cordlength_to_arclength(chord_length):
+def _chordlength_to_arclength(chord_length):
     """
     Convert 3D (Euclidean) distance to great circle arc length
     https://en.wikipedia.org/wiki/Great-circle_distance
@@ -175,7 +175,7 @@ def _cordlength_to_arclength(chord_length):
     return central_angle
 
 
-def _arclength_to_cordlength(arc_length):
+def _arclength_to_chordlength(arc_length):
     """
     Convert great circle arc length to 3D (Euclidean) distance
     https://en.wikipedia.org/wiki/Great-circle_distance
@@ -206,9 +206,9 @@ class GeoKDTree:
         # TODO: allow user to specify max distance
         self.max_distance_arc = np.pi / 4
         if self.max_distance_arc <= np.pi:
-            self.max_distance_cord = _arclength_to_cordlength(self.max_distance_arc)
+            self.max_distance_chord = _arclength_to_chordlength(self.max_distance_arc)
         else:
-            self.max_distance_cord = np.inf
+            self.max_distance_chord = np.inf
 
     def nearest_point(self, ref_points, figure=IFS_SPHERE):
         """Find the index of the nearest point to all ``ref_points``.
@@ -240,7 +240,7 @@ class GeoKDTree:
             points, distance_upper_bound=self.max_distance_arc
         )
 
-        return index, figure.scale(_cordlength_to_arclength(distance))
+        return index, figure.scale(_chordlength_to_arclength(distance))
 
 
 def nearest_point_kdtree(ref_points, points, figure=IFS_SPHERE):

--- a/earthkit/geo/figure.py
+++ b/earthkit/geo/figure.py
@@ -46,7 +46,7 @@ class UnitSphere(Sphere):
             return args[0]
 
 
-IFS_SPHERE = Sphere(6371229)
+IFS_SPHERE = Sphere(6371229.0)
 r"""Object of spherical Earth with radius=6371229 m as used in the IFS.
 See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12)."""
 

--- a/earthkit/geo/figure.py
+++ b/earthkit/geo/figure.py
@@ -33,20 +33,11 @@ class Sphere(Figure):
             return args[0] * self.radius
 
 
-class IFSSphere(Sphere):
-    r"""Spherical Earth with radius=6371229 m as used in the IFS.
-    See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12).
-    """
-
-    def __init__(self):
-        super().__init__(6371229)
-
-
 class UnitSphere(Sphere):
     """Unit sphere (with the radius of 1 m)."""
 
     def __init__(self):
-        super().__init__(1)
+        super().__init__(1.0)
 
     def scale(self, *args):
         if len(args) > 1:
@@ -55,7 +46,7 @@ class UnitSphere(Sphere):
             return args[0]
 
 
-IFS_SPHERE = IFSSphere()
+IFS_SPHERE = Sphere(6371229)
 r"""Object of spherical Earth with radius=6371229 m as used in the IFS.
 See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12)."""
 

--- a/earthkit/geo/figure.py
+++ b/earthkit/geo/figure.py
@@ -17,14 +17,10 @@ class Figure:
 class Sphere(Figure):
     """Base class for a sphere. The radius is in metres."""
 
-    _radius = None
-
-    def __init__(self):
-        if self._radius is None:
-            raise NotImplementedError("Use a subclass of Sphere")
-
-    def __init_subclass__(self):
-        pass
+    def __init__(self, radius):
+        self._radius = radius
+        if self._radius <= 0.0:
+            raise ValueError(f"Radius={self._radius} must be positive")
 
     @property
     def radius(self):
@@ -42,13 +38,15 @@ class IFSSphere(Sphere):
     See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12).
     """
 
-    _radius = 6371229
+    def __init__(self):
+        super().__init__(6371229)
 
 
 class UnitSphere(Sphere):
     """Unit sphere (with the radius of 1 m)."""
 
-    _radius = 1.0
+    def __init__(self):
+        super().__init__(1)
 
     def scale(self, *args):
         if len(args) > 1:

--- a/earthkit/geo/figure.py
+++ b/earthkit/geo/figure.py
@@ -1,0 +1,65 @@
+# (C) Copyright 2024 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+class Figure:
+    """Figure representing the size and shape of a spheroid"""
+
+    pass
+
+
+class Sphere(Figure):
+    """Base class for a sphere. The radius is in metres."""
+
+    _radius = None
+
+    def __init__(self):
+        if self._radius is None:
+            raise NotImplementedError("Use a subclass of Sphere")
+
+    def __init_subclass__(self):
+        pass
+
+    @property
+    def radius(self):
+        return self._radius
+
+    def scale(self, *args):
+        if len(args) > 1:
+            return tuple([x * self.radius for x in args])
+        else:
+            return args[0] * self.radius
+
+
+class IFSSphere(Sphere):
+    r"""Spherical Earth with radius=6371229 m as used in the IFS.
+    See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12).
+    """
+
+    _radius = 6371229
+
+
+class UnitSphere(Sphere):
+    """Unit sphere (with the radius of 1 m)."""
+
+    _radius = 1.0
+
+    def scale(self, *args):
+        if len(args) > 1:
+            return args
+        else:
+            return args[0]
+
+
+IFS_SPHERE = IFSSphere()
+r"""Object of spherical Earth with radius=6371229 m as used in the IFS.
+See [IFS-CY47R3-PhysicalProcesses]_ (Chapter 12)."""
+
+UNIT_SPHERE = UnitSphere()
+r"""Object of unit sphere (with the radius of 1 m)."""

--- a/tests/distance/test_distance.py
+++ b/tests/distance/test_distance.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from earthkit.geo import (
+    UNIT_SPHERE,
     haversine_distance,
     nearest_point_haversine,
     nearest_point_kdtree,
@@ -108,7 +109,7 @@ def test_haversine_distance_with_radius():
     p_ref = (48.0, 20)
     d_ref = 1.33989384590445
 
-    d = haversine_distance(p_ref, p, radius=1)
+    d = haversine_distance(p_ref, p, figure=UNIT_SPHERE)
     assert np.allclose(d, d_ref)
 
 
@@ -157,7 +158,7 @@ def test_nearest_single_ref_with_radius(mode, p_ref, index_ref, dist_ref):
     lons = np.array([0, 90, -90, 180, 0, 0, 20, -20, -20, 20, 1.0])
 
     meth = get_nearest_method(mode)
-    index, distance = meth(p_ref, (lats, lons), radius=1)
+    index, distance = meth(p_ref, (lats, lons), figure=UNIT_SPHERE)
     assert np.allclose(index_ref, index)
     assert np.allclose(distance, dist_ref)
 


### PR DESCRIPTION
This PR adds the `figure` option to all the relevant methods and ensures that the nearest methods do not scale unnecessary with the radius of the earth.

See documentation at: https://earthkit-geo.readthedocs.io/en/feature-review-usage-of-radius-of-earth/_api/geo/distance/index.html