### PR TITLE
Adds GISCO interface

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - cartopy
 - shapely
 - scipy
+- requests
 - make
 - mypy
 - myst-parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 dependencies = [
   "pyproj",
   "cartopy",
-  "scipy"
+  "scipy",
+  "requests"
 ]
 description = "Geospatial computations"
 dynamic = ["version"]

--- a/src/earthkit/geo/gisco.py
+++ b/src/earthkit/geo/gisco.py
@@ -32,11 +32,8 @@ AVAILABLE_YEARS = {
 }
 
 
-_writable_dir = Path.home() / ".local" / "share"
-_default_data_dir = (
-    Path(os.environ.get("XDG_DATA_HOME", _writable_dir)) / "earthkit-geo"
-)
-DATA_DIR = Path(os.environ.get("EARTHKIT_GEO_DATA_DIR", _default_data_dir))
+_DEFAULT_DATA_DIR = Path.home() / ".cache" / "earthkit-geo"
+DATA_DIR = Path(os.environ.get("EARTHKIT_GEO_DATA_DIR", _DEFAULT_DATA_DIR))
 
 
 def _get_gisco_cache_dir():

--- a/src/earthkit/geo/gisco.py
+++ b/src/earthkit/geo/gisco.py
@@ -1,0 +1,179 @@
+# (C) Copyright 2024 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import os
+import warnings
+from pathlib import Path
+from zipfile import ZipFile
+
+import requests
+
+GISCO_RESOLUTIONS = ["01M", "03M", "10M", "20M", "60M"]
+
+GISCO_GEOMETRY_TYPES = {
+    "polygons": "RG",
+    "lines": "BN",
+    "points": "LB",
+}
+
+GISCO_URL_TEMPLATE = (
+    "https://gisco-services.ec.europa.eu" "/distribution/v2/{category}/shp"
+)
+
+AVAILABLE_YEARS = {
+    "nuts": [2024, 2021, 2016, 2013, 2010, 2006, 2003],
+    "countries": [2024, 2020, 2016, 2013, 2010, 2006, 2001],
+}
+
+
+_writable_dir = Path.home() / ".local" / "share"
+_default_data_dir = (
+    Path(os.environ.get("XDG_DATA_HOME", _writable_dir)) / "earthkit-geo"
+)
+DATA_DIR = Path(os.environ.get("EARTHKIT_GEO_DATA_DIR", _default_data_dir))
+
+
+def _get_gisco_cache_dir():
+    """Return (and create if missing) the base directory where GISCO shapefiles will be stored."""
+    cache_dir = DATA_DIR / "gisco-data"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def _load_with_earthkit_data(path):
+    """Load shapefile with earthkit.data if available, warn otherwise."""
+    try:
+        import earthkit.data
+    except ImportError:
+        warnings.warn(
+            "The 'earthkit.data' package is not installed; returning the file path instead."
+        )
+        return path
+    else:
+        return earthkit.data.from_source("file", path)
+
+
+class DownloadWarning(Warning):
+    """Warning for download operations."""
+
+
+def _download_and_cache_gisco(
+    name, category, geometry_type, resolution, suffix="", year=2024
+):
+    """
+    Download (if needed) and unzip the GISCO shapefile for a given
+    country code `name` and resolution. Returns the path to the .shp file.
+    """
+    # Convert geometry_type if needed
+    if geometry_type not in GISCO_GEOMETRY_TYPES.values():
+        try:
+            geometry_type = GISCO_GEOMETRY_TYPES[geometry_type]
+        except KeyError:
+            raise ValueError(
+                f"Invalid geometry type '{geometry_type}'. "
+                f"Valid types are: {list(GISCO_GEOMETRY_TYPES.keys())}"
+            )
+
+    # Validate year
+    if year not in AVAILABLE_YEARS.get(category, []):
+        raise ValueError(
+            f"Year {year} is not available for category '{category}'. "
+            f"Available years: {AVAILABLE_YEARS.get(category, [])}"
+        )
+
+    # Only include resolution if not LB
+    resolution_str = resolution if geometry_type != "LB" and resolution else ""
+    filename_parts = [name, geometry_type]
+    if resolution_str:
+        filename_parts.append(resolution_str)
+    filename_parts.append(str(year))
+    filename_parts.append("4326")  # CRS
+    if suffix:
+        filename_parts.append(suffix.lstrip("_"))
+    filename = "_".join(filename_parts) + ".shp.zip"
+
+    # Set up paths
+    cache_dir = _get_gisco_cache_dir()
+    zip_path = cache_dir / filename
+    extract_dir = (
+        cache_dir / "_".join([name, resolution_str])
+        if resolution_str
+        else cache_dir / name
+    )
+    shp_path = extract_dir / filename.replace(".zip", "")
+
+    # Download and extract if needed
+    if not shp_path.exists():
+        if not zip_path.exists():
+            url = f"{GISCO_URL_TEMPLATE.format(category=category)}/{filename}"
+            warnings.warn(f"Downloading: {url}", DownloadWarning)
+            resp = requests.get(url)
+            resp.raise_for_status()
+            zip_path.write_bytes(resp.content)
+        extract_dir.mkdir(parents=True, exist_ok=True)
+        with ZipFile(zip_path, "r") as zf:
+            zf.extractall(extract_dir)
+
+    return str(shp_path)
+
+
+def nuts_regions(level, resolution="10M", year=2024, geometry_type="polygons"):
+    """
+    Retrieve NUTS regions of the given level.
+
+    Please see https://ec.europa.eu/eurostat/web/nuts for more information.
+
+    Parameters
+    ----------
+    level : int
+        The NUTS level (0, 1, 2, or 3).
+    resolution : str, optional
+        The desired resolution of the shapefile. Must be one of the following:
+        '01M', '03M', '10M', '20M', or '60M'. Default is '10M'.
+    geometry_type : str, optional
+        The type of geometry to retrieve. Must be one of 'polygons', 'lines', or 'points'.
+        Default is 'polygons'.
+    year : int, optional
+        The year of the NUTS data to retrieve. Default is 2024 (latest available).
+    """
+    suffix = f"_LEVL_{level}"
+    path = _download_and_cache_gisco(
+        name="NUTS",
+        category="nuts",
+        geometry_type=geometry_type,
+        resolution=resolution,
+        suffix=suffix,
+        year=year,
+    )
+    return _load_with_earthkit_data(path)
+
+
+def countries(resolution="10M", year=2024, geometry_type="polygons"):
+    """
+    Retrieve country boundaries.
+
+    Parameters
+    ----------
+    resolution : str, optional
+        The desired resolution of the shapefile. Must be one of the following:
+        '01M', '03M', '10M', '20M', or '60M'. Default is '10M'.
+    geometry_type : str, optional
+        The type of geometry to retrieve. Must be one of 'polygons', 'lines', or 'points'.
+        Default is 'polygons'.
+    year : int, optional
+        The year of the country data to retrieve. Default is 2024 (latest available).
+    """
+    path = _download_and_cache_gisco(
+        name="CNTR",
+        category="countries",
+        geometry_type=geometry_type,
+        resolution=resolution,
+        year=year,
+    )
+    return _load_with_earthkit_data(path)

--- a/src/earthkit/geo/gisco.py
+++ b/src/earthkit/geo/gisco.py
@@ -107,15 +107,21 @@ def _download_and_cache_gisco(
 
     # Download and extract if needed
     if not shp_path.exists():
-        if not zip_path.exists():
-            url = f"{GISCO_URL_TEMPLATE.format(category=category)}/{filename}"
-            warnings.warn(f"Downloading: {url}", DownloadWarning)
-            resp = requests.get(url)
-            resp.raise_for_status()
-            zip_path.write_bytes(resp.content)
-        extract_dir.mkdir(parents=True, exist_ok=True)
-        with ZipFile(zip_path, "r") as zf:
-            zf.extractall(extract_dir)
+        from filelock import FileLock
+
+        lock = str(zip_path) + ".lock"
+        with FileLock(lock):
+            # Check again, another thread/process may have created the file
+            if not shp_path.exists():
+                if not zip_path.exists():
+                    url = f"{GISCO_URL_TEMPLATE.format(category=category)}/{filename}"
+                    warnings.warn(f"Downloading: {url}", DownloadWarning)
+                    resp = requests.get(url)
+                    resp.raise_for_status()
+                    zip_path.write_bytes(resp.content)
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                with ZipFile(zip_path, "r") as zf:
+                    zf.extractall(extract_dir)
 
     return str(shp_path)
 

--- a/tests/downstream-ci-requirements.txt
+++ b/tests/downstream-ci-requirements.txt
@@ -1,5 +1,6 @@
 pyproj
 scipy
+requests
 # for testing
 pytest
 pytest-cov

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - pyproj
 - scipy
+- requests
 - make
 - myst-parser
 - pre-commit

--- a/tests/test_gisco.py
+++ b/tests/test_gisco.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2024 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import sys
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from earthkit.geo import gisco
+
+
+def test_invalid_geometry_type_raises():
+    with pytest.raises(ValueError, match="Invalid geometry type"):
+        gisco._download_and_cache_gisco(
+            name="CNTR",
+            category="countries",
+            geometry_type="banana",
+            resolution="60M",
+            year=2024,
+        )
+
+
+def test_invalid_year_raises():
+    with pytest.raises(ValueError, match="Year 1999 is not available"):
+        gisco._download_and_cache_gisco(
+            name="CNTR",
+            category="countries",
+            geometry_type="polygons",
+            resolution="60M",
+            year=1999,
+        )
+
+
+def test_valid_geometry_type():
+    with patch("requests.get"):
+        with patch.object(Path, "exists", return_value=True):
+            # geometry_type 'polygons' is 'RG'
+            path = gisco._download_and_cache_gisco(
+                name="NUTS",
+                category="nuts",
+                geometry_type="polygons",
+                resolution="01M",
+                year=2024,
+            )
+            assert "NUTS_RG_01M_2024_4326.shp" in path
+
+
+def test_filename_construction_with_suffix():
+    with patch("requests.get"):
+        with patch.object(Path, "exists", return_value=True):
+            # geometry_type 'polygons' is 'RG'
+            path = gisco._download_and_cache_gisco(
+                name="NUTS",
+                category="nuts",
+                geometry_type="polygons",
+                resolution="01M",
+                year=2024,
+                suffix="_LEVL_2",
+            )
+            assert "NUTS_RG_01M_2024_4326_LEVL_2.shp" in path
+
+
+def test_filename_construction_countries():
+    with patch("requests.get"):
+        with patch.object(Path, "exists", return_value=True):
+            # geometry_type 'polygons' is 'RG'
+            path = gisco._download_and_cache_gisco(
+                name="CNTR",
+                category="countries",
+                geometry_type="polygons",
+                resolution="01M",
+                year=2024,
+            )
+            assert "CNTR_RG_01M_2024_4326.shp" in path
+
+
+def test_load_with_earthkit_data_warns(monkeypatch):
+    monkeypatch.setitem(sys.modules, "earthkit.data", None)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = gisco._load_with_earthkit_data("dummy_path")
+        assert any("not installed" in str(wi.message) for wi in w)
+        assert result == "dummy_path"


### PR DESCRIPTION
### Description

This PR introduces a new `earthkit.geo.gisco` module for retrieving, caching, and loading shapefiles from the Eurostat GISCO API. There are two main motivations for this:

- To make these shapes easily available for visualisation with earthkit-plots.
- To make these shapes available for spatial aggregations with earthkit-transforms - particularly for C3S users, who commonly need to average climate data over the NUTS regions of Europe.

### Features

#### Automatic Download and Caching:

Functions such as `gisco.nuts_regions()` and `gisco.countries()` will automatically check if the requested shapefile is already present in a local cache. If not, the shapefile is downloaded from the Eurostat GISCO API, extracted, and stored for future use.

#### Caching

The caching mechanism closely mirrors the approach used by cartopy, storing downloaded shapefiles in a dedicated directory (by default, `~/.local/share/earthkit-geo/gisco-data/`, or as configured via environment variables). This means GISCO shapefiles are cached alongside the shapefiles cartopy caches from Natural Earth.

#### earthkit-data integration

If earthkit-data is installed, the function will return a ready-to-use GeoPandas GeoDataFrame of the shapes, enabling immediate plotting and analysis.

If earthkit-data is **not** installed, a warning is raised and the function returns the file path to the cached shapefile instead, allowing for manual loading.