### PR TITLE
Fix url path separators

### DIFF
--- a/src/earthkit/geo/regrid/backends/db.py
+++ b/src/earthkit/geo/regrid/backends/db.py
@@ -17,6 +17,7 @@ from scipy.sparse import load_npz
 from earthkit.geo.regrid.gridspec import GridSpec
 from earthkit.geo.utils import no_progress_bar
 from earthkit.geo.utils.download import download_and_cache
+from earthkit.geo.utils.url import join_url_path
 
 LOG = logging.getLogger(__name__)
 
@@ -124,7 +125,7 @@ class UrlAccessor(MatrixAccessor):
     def _get_index(self, check_remote=False, force=False):
         from earthkit.geo.utils.caching import cache_file
 
-        url = os.path.join(self._url, _INDEX_FILENAME)
+        url = join_url_path(self._url, _INDEX_FILENAME)
 
         def _compare_sha(args, path, owner_data):
             """Decide if the index file should be downloaded and cached again."""
@@ -206,7 +207,7 @@ class UrlAccessor(MatrixAccessor):
 
     def _remote_sha(self):
         try:
-            url = os.path.join(self._url, _INDEX_SHA_FILENAME)
+            url = join_url_path(self._url, _INDEX_SHA_FILENAME)
             path = download_and_cache(
                 url,
                 owner="url",
@@ -229,7 +230,7 @@ class UrlAccessor(MatrixAccessor):
 
     def _gzip_file(self):
         try:
-            url = os.path.join(self._url, _INDEX_GZ_FILENAME)
+            url = join_url_path(self._url, _INDEX_GZ_FILENAME)
             LOG.info(f"Download gzipped index file={url}")
             path = download_and_cache(
                 url,
@@ -251,7 +252,7 @@ class UrlAccessor(MatrixAccessor):
 
     def matrix_path(self, name):
         try:
-            url = os.path.join(self._url, name)
+            url = join_url_path(self._url, name)
             path = download_and_cache(
                 url,
                 owner="url",

--- a/src/earthkit/geo/utils/testing.py
+++ b/src/earthkit/geo/utils/testing.py
@@ -11,6 +11,8 @@ from importlib import import_module
 
 import numpy as np
 
+from earthkit.geo.utils.url import join_url_path
+
 PATH = os.path.dirname(__file__)
 
 URL_ROOT = "https://sites.ecmwf.int/repository/earthkit-geo/test-data"
@@ -50,7 +52,7 @@ def get_test_data(filename, subfolder="global_0_360"):
         os.makedirs(d_path, exist_ok=True)
         f_path = os.path.join(d_path, fn)
         if not os.path.exists(f_path):
-            simple_download(url=f"{URL_ROOT}/{subfolder}/{fn}", target=f_path)
+            simple_download(url=join_url_path(URL_ROOT, subfolder, fn), target=f_path)
         res.append(f_path)
 
     if len(res) == 1:

--- a/src/earthkit/geo/utils/url.py
+++ b/src/earthkit/geo/utils/url.py
@@ -1,0 +1,14 @@
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+def join_url_path(root, *args):
+    if not args:
+        return root
+    return f"{root.rstrip('/')}" + "/" + "/".join(args)

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2023 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+import pytest
+
+from earthkit.geo.utils.url import join_url_path
+
+
+@pytest.mark.parametrize(
+    "root,args,expected",
+    [
+        ("http://example.com", [], "http://example.com"),
+        ("http://example.com/", [], "http://example.com/"),
+        ("http://example.com", ["path"], "http://example.com/path"),
+        ("http://example.com/", ["path"], "http://example.com/path"),
+        ("http://example.com", ["path", "to", "file"], "http://example.com/path/to/file"),
+        ("http://example.com/", ["path", "to", "file"], "http://example.com/path/to/file"),
+    ],
+)
+def test_join_url_path(root, args, expected):
+    assert join_url_path(root, *args) == expected


### PR DESCRIPTION
### Description

The PR ensures that all URL paths use "/" as a separator. 

The original issue was reported in earthkit-regrid: https://github.com/ecmwf/earthkit-regrid/issues/122


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 