### PR TITLE
Preserve grib metadata for precomputed backend and allow using non-grib fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.test = [
   "earthkit-utils>=1.0.0rc0",
-  "earthkit-data>=1.0.0rc0",
+  "earthkit-data>=1.0.0rc5",
   "pytest",
   "pytest-cov"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.test = [
   "earthkit-utils>=1.0.0rc0",
-  "earthkit-data>=1.0.0rc5",
+  "earthkit-data>=1.0.0rc4",
   "pytest",
   "pytest-cov"
 ]

--- a/src/earthkit/geo/regrid/data/fieldlist.py
+++ b/src/earthkit/geo/regrid/data/fieldlist.py
@@ -5,8 +5,9 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-#
 
+
+import json
 import logging
 
 from .handler import DataHandler
@@ -48,28 +49,77 @@ class FieldListDataHandler(DataHandler):
         if grid is None:
             raise ValueError("Missing 'grid' argument")
 
-        if hasattr(backend, "regrid_grib"):
-            # TODO: remove this when ecCodes supports setting the gridSpec on a GRIB handle
-            return self._regrid_grib(data, backend, grid, **kwargs)
-        else:
-            return self._regrid_array(data, backend, grid, **kwargs)
-
-    def _regrid_array(self, data, backend, grid, **kwargs):
-        import earthkit.data
-
-        ds = data
-        assert grid is not None
-
-        # TODO: refactor this when this limitation is removed
-        from earthkit.geo.regrid.gridspec import GridSpec
-
-        out_grid = GridSpec.from_any(grid)
-
         fields = []
-        for i, f in enumerate(ds):
-            vv = f.to_numpy(flatten=True)
+        for i, field in enumerate(data):
+            r = self._regrid_field(field, i, backend, grid, **kwargs)
+            fields.append(r)
 
-            in_grid = self.input_gridspec(f, i)
+        from earthkit.data import FieldList
+
+        return FieldList.from_fields(fields)
+
+    def _regrid_field(self, field, index, backend, grid, **kwargs):
+        message = None
+        if field._get_grib():
+            message = field.message()
+
+        # GRIB data
+        if message is not None:
+            from earthkit.data.field.grib.create import create_grib_field_from_buffer
+
+            # currently this means the mir backend
+            if hasattr(backend, "regrid_grib"):
+                v_res = backend.regrid_grib(message, grid, **kwargs)
+                return create_grib_field_from_buffer(v_res, template_field=field)
+
+            # currently this means the precomputed backend
+            else:
+                from earthkit.geo.regrid.gridspec import GridSpec
+
+                vv = field.to_numpy(flatten=True)
+
+                in_grid = self.input_gridspec(field, index)
+
+                # for precomputed backend we need to build a special gridspec object
+                # to match the matrix inventory items
+                # TODO: remove this limitation
+                in_grid = GridSpec.from_any(in_grid)
+                out_grid = GridSpec.from_any(grid)
+
+                v_res, out_grid = backend.regrid(
+                    vv,
+                    in_grid,
+                    out_grid,
+                    **kwargs,
+                )
+                from eckit.geo import Grid
+
+                out_grid = Grid(out_grid)
+                # convert gridspec to string as this is what ecCodes expects in the "gridSpec" key w
+                out_spec = json.dumps(out_grid.spec)
+
+                # when the field has an associated GRIB message, we
+                # use a GribEncoder to encode the resulting data and preserve
+                # the original GRIB metadata as much as possible (bar the grid)
+                from earthkit.data.encoders.grib import GribEncoder
+
+                encoder = GribEncoder()
+                d = encoder.encode(template=message, values=v_res, gridSpec=out_spec)
+                return create_grib_field_from_buffer(d.to_bytes(), template_field=field)
+
+        else:
+            vv = field.to_numpy(flatten=True)
+            in_grid = self.input_gridspec(field, index)
+
+            # currently this is the mir backend
+            if not hasattr(backend, "regrid_grib"):
+                # for precomputed backend we need to build a special gridspec object
+                # to match the matrix inventory items
+                # TODO: remove this limitation
+                from earthkit.geo.regrid.gridspec import GridSpec
+
+                in_grid = GridSpec.from_any(in_grid)
+                out_grid = GridSpec.from_any(grid)
 
             v_res, out_grid = backend.regrid(
                 vv,
@@ -77,39 +127,11 @@ class FieldListDataHandler(DataHandler):
                 out_grid,
                 **kwargs,
             )
+            from eckit.geo import Grid
 
-            out_grid = GridSpec.from_any(out_grid).grid
+            out_grid = Grid(out_grid)
 
-            fields.append(f.set({"values": v_res, "geography.grid_spec": out_grid}))
-
-        r = earthkit.data.create_fieldlist(fields)
-
-        return r
-
-    def _regrid_grib(self, values, backend, grid, **kwargs):
-        # TODO: remove this when ecCodes supports setting the gridSpec on a GRIB handle
-        from earthkit.data.encoders.grib import GribEncoder
-        from earthkit.data.field.grib.create import create_grib_field_from_buffer
-
-        assert hasattr(backend, "regrid_grib")
-
-        ds = values
-        assert grid is not None
-
-        encoder = GribEncoder()
-
-        r = []
-        for i, f in enumerate(ds):
-            if f._get_grib():
-                d = encoder.encode(f)
-                message = d.to_bytes()
-                if message is None:
-                    raise ValueError(f"field at index={i} type={type(f)} is not supported in regrid!")
-
-            v_res = backend.regrid_grib(message, grid, **kwargs)
-            r.append(create_grib_field_from_buffer(v_res))
-
-        return ds.from_fields(r)
+            return field.set({"values": v_res, "geography.grid_spec": out_grid})
 
 
 class FieldDataHandler(DataHandler):

--- a/src/earthkit/geo/regrid/data/fieldlist.py
+++ b/src/earthkit/geo/regrid/data/fieldlist.py
@@ -101,6 +101,9 @@ class FieldListDataHandler(DataHandler):
                 # when the field has an associated GRIB message, we
                 # use a GribEncoder to encode the resulting data and preserve
                 # the original GRIB metadata as much as possible (bar the grid)
+
+                # TODO: avoid using a GribEncoder once the grid(spec) handling in the
+                # earthkit-data field is improved
                 from earthkit.data.encoders.grib import GribEncoder
 
                 encoder = GribEncoder()
@@ -111,7 +114,7 @@ class FieldListDataHandler(DataHandler):
             vv = field.to_numpy(flatten=True)
             in_grid = self.input_gridspec(field, index)
 
-            # currently this is the mir backend
+            # currently this is the precomputed backend
             if not hasattr(backend, "regrid_grib"):
                 # for precomputed backend we need to build a special gridspec object
                 # to match the matrix inventory items
@@ -120,6 +123,8 @@ class FieldListDataHandler(DataHandler):
 
                 in_grid = GridSpec.from_any(in_grid)
                 out_grid = GridSpec.from_any(grid)
+            else:
+                out_grid = grid
 
             v_res, out_grid = backend.regrid(
                 vv,

--- a/tests/regrid/regrid_backends/test_matrix_fieldlist.py
+++ b/tests/regrid/regrid_backends/test_matrix_fieldlist.py
@@ -48,7 +48,7 @@ def _create_fieldlist(filename, field_type):
 )
 @pytest.mark.parametrize("field_type", ["grib", "array"])
 @pytest.mark.parametrize("out_grid", [{"grid": [10, 10]}, Grid({"grid": [10, 10]}), "'grid': [10, 10]"])
-def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation, field_type, out_grid):
+def test_regrid_matrix_fieldlist_reg_ll_grib(_kwarg, interpolation, field_type, out_grid):
     ds = _create_fieldlist("5x5.grib", field_type)
 
     f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
@@ -65,7 +65,35 @@ def test_regrid_matrix_fieldlist_reg_ll(_kwarg, interpolation, field_type, out_g
     grid_ref = Grid({"grid": [10, 10]}).spec
 
     for f in r:
-        assert f.geography.grid().spec == grid_ref
+        assert f.geography.grid_spec() == grid_ref
+
+
+def test_regrid_matrix_fieldlist_reg_ll_non_grib():
+    interpolation = "linear"
+    field_type = "grib"
+    out_grid = {"grid": [10, 10]}
+
+    fl_ori = _create_fieldlist("5x5.grib", field_type)
+    fl = fl_ori.set({"parameter.variable": "msl", "labels": {"my_label": "my_value"}})
+
+    # the fields are now decoupled from the original grib messages
+    assert fl[0].message() is None, "Field should not have a GRIB message after setting new metadata"
+
+    f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
+    v_ref = np.load(f_ref)["arr_0"]
+
+    r = regrid(fl, grid=out_grid, backend=SYSTEM_MATRIX_BACKEND_NAME, interpolation=interpolation)
+
+    assert len(r) == 1
+    assert r[0].geography.shape() == (19, 36)
+    assert np.allclose(r[0].values, v_ref)
+    assert r[0].get("parameter.variable") == "msl"
+    assert r[0].get("labels.my_label") == "my_value"
+
+    grid_ref = Grid({"grid": [10, 10]}).spec
+
+    for f in r:
+        assert f.geography.grid_spec() == grid_ref
 
 
 @pytest.mark.download
@@ -100,7 +128,7 @@ def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation, field_type, out_grid)
     grid_ref = Grid({"grid": [10, 10]}).spec
 
     for f in r:
-        assert f.geography.grid().spec == grid_ref
+        assert f.geography.grid_spec() == grid_ref
 
 
 @pytest.mark.download
@@ -118,20 +146,51 @@ def test_regrid_matrix_fieldlist_gg(_kwarg, interpolation, field_type, out_grid)
 )
 @pytest.mark.parametrize("field_type", ["grib", "array"])
 @pytest.mark.parametrize("out_grid", [{"grid": [10, 10]}, Grid({"grid": [10, 10]}), "'grid': [10, 10]"])
-def test_regrid_matrix_single_field(_kwarg, interpolation, field_type, out_grid):
+def test_regrid_matrix_single_field_grib(_kwarg, interpolation, field_type, out_grid):
     ds = _create_fieldlist("5x5.grib", field_type)
 
     f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
     v_ref = np.load(f_ref)["arr_0"]
     field = ds[0]
+    field = field.set(labels={"my_label": "my_value"})
     metadata_ref = field.metadata(["param", "level", "date", "time"])
 
     r = regrid(field, grid=out_grid, backend=SYSTEM_MATRIX_BACKEND_NAME, **_kwarg)
 
     assert r.geography.shape() == (19, 36)
     assert np.allclose(r.values, v_ref)
+    assert r.get("labels.my_label") == "my_value"
     assert r.metadata(["param", "level", "date", "time"]) == metadata_ref
 
     grid_ref = Grid({"grid": [10, 10]}).spec
 
-    assert r.geography.grid().spec == grid_ref
+    assert r.geography.grid_spec() == grid_ref
+
+
+@pytest.mark.download
+@pytest.mark.tmp_cache
+@pytest.mark.skipif(NO_EKD, reason="No access to earthkit-data")
+def test_regrid_matrix_single_field_non_grib():
+    interpolation = "linear"
+    out_grid = {"grid": [10, 10]}
+    field_type = "array"
+
+    fl = _create_fieldlist("5x5.grib", field_type)
+    field = fl[0].set({"parameter.variable": "msl"}, labels={"my_label": "my_value"})
+
+    # the field is now decoupled from the original grib message
+    assert field.message() is None
+
+    f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
+    v_ref = np.load(f_ref)["arr_0"]
+
+    r = regrid(field, grid=out_grid, backend=SYSTEM_MATRIX_BACKEND_NAME, interpolation=interpolation)
+
+    assert r.geography.shape() == (19, 36)
+    assert np.allclose(r.values, v_ref)
+    assert r.get("parameter.variable") == "msl"
+    assert r.get("labels.my_label") == "my_value"
+
+    grid_ref = Grid({"grid": [10, 10]}).spec
+
+    assert r.geography.grid_spec() == grid_ref

--- a/tests/regrid/regrid_mir/test_regrid_fieldlist.py
+++ b/tests/regrid/regrid_mir/test_regrid_fieldlist.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import pytest
+from eckit.geo import Grid
 
 from earthkit.geo.regrid import regrid
 from earthkit.geo.utils.testing import (
@@ -133,3 +134,33 @@ def test_regrid_single_field(_kwarg, interpolation, field_type):
         assert np.isclose(r.metadata(k), v), k
 
     assert r.metadata("gridType") == "regular_ll"
+
+
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
+@pytest.mark.skipif(NO_EKD, reason="No access to earthkit-data")
+@pytest.mark.download
+@pytest.mark.tmp_cache
+def test_regrid_single_field_non_grib():
+    interpolation = "linear"
+    out_grid = {"grid": [10, 10]}
+    field_type = "array"
+
+    fl = _create_fieldlist("5x5.grib", field_type)
+    field = fl[0].set({"parameter.variable": "msl"}, labels={"my_label": "my_value"})
+
+    # the field is now decoupled from the original grib message
+    assert field.message() is None
+
+    f_ref = get_test_data(f"out_5x5_10x10_{interpolation}.npz")
+    v_ref = np.load(f_ref)["arr_0"]
+
+    r = regrid(field, grid=out_grid, interpolation=interpolation)
+
+    assert r.geography.shape() == (19, 36)
+    assert np.allclose(r.values, v_ref)
+    assert r.get("parameter.variable") == "msl"
+    assert r.get("labels.my_label") == "my_value"
+
+    grid_ref = Grid({"grid": [10, 10]}).spec
+
+    assert r.geography.grid_spec() == grid_ref


### PR DESCRIPTION
### Description

Requires earthkit-data>=1.0.0rc4


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
