### PR TITLE
Feature/xarray gridspec attribute

### DIFF
--- a/docs/concepts/regridding/mir/regrid_high.rst
+++ b/docs/concepts/regridding/mir/regrid_high.rst
@@ -20,7 +20,7 @@ regrid (high-level) with MIR
         - an :class:`xarray.DataArray` or :class:`xarray.Dataset`. Please note this is an **experimental** feature and
           only works if the input :ref:`gridspec <gridspec>` can be automatically inferred from the data. If the
           Xarray was created with ``earthkit-data`` it most probably contains the necessary metadata to be automatically
-          inferred. Otherwise, the Xarray dataset/dataarray must have the ``ek_grid_spec`` attribute containing
+          inferred. Otherwise, the Xarray dataset/dataarray must have the ``earthkit_grid_spec`` attribute containing
           the :ref:`gridspec <gridspec>` as a dict or a JSON string.
 
     :type data: :py:class:`~earthkit.data.core.fieldlist.FieldList`, :py:class:`~earthkit.data.core.field.Field`, bytes, :class:`io.BytesIO`, :class:`xarray.DataArray`, :class:`xarray.Dataset`

--- a/docs/release-notes/version_1.0.0rc_updates.rst
+++ b/docs/release-notes/version_1.0.0rc_updates.rst
@@ -4,6 +4,12 @@ Version 1.0.0 Release Candidate Updates
 /////////////////////////////////////////
 
 
+Version 1.0.0rc7
+==================
+
+- Use ``earthkit_grid_spec`` instead of ``ek_grid_spec`` as the attribute name for the grid specification in Xarray input for :func:`regrid` (:pr:`63`).
+
+
 Version 1.0.0rc6
 ==================
 

--- a/docs/release-notes/version_1.0.0rc_updates.rst
+++ b/docs/release-notes/version_1.0.0rc_updates.rst
@@ -7,7 +7,7 @@ Version 1.0.0 Release Candidate Updates
 Version 1.0.0rc7
 ==================
 
-- Use ``earthkit_grid_spec`` instead of ``ek_grid_spec`` as the attribute name for the grid specification in Xarray input for :func:`regrid` (:pr:`63`).
+- Use ``earthkit_grid_spec`` instead of ``ek_grid_spec`` as the attribute name for the grid specification in Xarray input for :func:`regrid` (:pr:`69`).
 
 
 Version 1.0.0rc6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ optional-dependencies.all = ["cartopy"]
 optional-dependencies.cartography = ["cartopy"]
 optional-dependencies.ci = [
   "earthkit-utils>=1.0.0rc0",
-  "earthkit-data>=1.0.0rc0",
+  "earthkit-data>=1.0.0rc6",
   "pytest",
   "pytest-cov",
   "requests",
@@ -66,7 +66,7 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.test = [
   "earthkit-utils>=1.0.0rc0",
-  "earthkit-data>=1.0.0rc4",
+  "earthkit-data>=1.0.0rc6",
   "pytest",
   "pytest-cov"
 ]

--- a/src/earthkit/geo/grids/_regrid/data/xarray.py
+++ b/src/earthkit/geo/grids/_regrid/data/xarray.py
@@ -221,21 +221,16 @@ class XarrayDataHandler(DataHandler):
         def _convert(grid_spec):
             if grid_spec is None:
                 return None
-            res = None
-            if isinstance(grid_spec, dict) and grid_spec:
-                res = grid_spec
+            elif isinstance(grid_spec, dict) and grid_spec:
+                return grid_spec
             elif isinstance(grid_spec, str):
                 import json
 
-                res = json.loads(grid_spec)
-
-            if res:
-                return res
-            else:
-                raise None
+                return json.loads(grid_spec)
+            return grid_spec
 
         try:
-            in_grid = _convert(ds.attrs.get("ek_grid_spec", None))
+            in_grid = _convert(ds.attrs.get("earthkit_grid_spec", None))
             if in_grid is None:
                 in_grid = _convert(kwargs.pop("grid_spec", None))
             if in_grid is None:


### PR DESCRIPTION
### Description

 Use `earthkit_grid_spec` instead of `ek_grid_spec` as the attribute name for the grid specification in Xarray input for `regrid()`.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
