### PR TITLE
Support non-trailing geo dims in xarray regrid

### DIFF
--- a/src/earthkit/geo/grids/_regrid/backends/mir.py
+++ b/src/earthkit/geo/grids/_regrid/backends/mir.py
@@ -56,6 +56,7 @@ class MirBackend(Backend):
         interpolation="linear",
     ):
         import mir
+        import numpy as np
 
         kwargs = {
             "interpolation": interpolation,
@@ -65,6 +66,10 @@ class MirBackend(Backend):
         out_grid = self.get_grid_spec(out_grid)
 
         out_grid, kwargs = self.adjust_options(out_grid, {})
+
+        # mir.ArrayInput requires a C-contiguous array but apply_ufunc's dim
+        # reordering can produce non-contiguous views. No-op if already contiguous.
+        data = np.ascontiguousarray(data)
 
         input = mir.ArrayInput(data, in_grid)
         out = mir.ArrayOutput()

--- a/src/earthkit/geo/grids/_regrid/data/xarray.py
+++ b/src/earthkit/geo/grids/_regrid/data/xarray.py
@@ -190,15 +190,23 @@ class XarrayGeographyBuilder:
 
 def xr_geo_dims(ds):
     """Determine the geographical dimensions of the dataset/dataarray."""
-    dims = list(ds.sizes.keys())
-    if len(ds.dims) >= 1:
-        if dims[-1] == "values":
-            return ["values"]
-    if len(dims) >= 2:
-        if dims[-2] == "latitude" and dims[-1] == "longitude":
-            return ["latitude", "longitude"]
+    dims = set(ds.sizes)
+    has_values = "values" in dims
+    has_latlon = {"latitude", "longitude"} <= dims
 
-    raise ValueError("Dataset geography is not supported.")
+    if has_values and has_latlon:
+        raise ValueError(
+            "Dataset geography is ambiguous: found both a 'values' dimension and 'latitude'/'longitude' dimensions."
+        )
+    if has_values:
+        return ["values"]
+    if has_latlon:
+        return ["latitude", "longitude"]
+
+    raise ValueError(
+        "Dataset geography is not supported. Expected dimensions ['values'] "
+        f"or ['latitude', 'longitude'], but found {sorted(dims)}."
+    )
 
 
 class XarrayDataHandler(DataHandler):

--- a/tests/regrid/regrid_mir/test_regrid_xarray.py
+++ b/tests/regrid/regrid_mir/test_regrid_xarray.py
@@ -111,6 +111,35 @@ def test_regrid_xarray_from_h_nested(out_grid, out_grid_ref, dims):
 @pytest.mark.skipif(NO_MIR, reason="No mir available")
 @pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
 @pytest.mark.parametrize(
+    "sample,out_grid,out_grid_ref,dims",
+    [
+        ("H8_nested_t2.grib2", {"grid": "N32"}, {"grid": "N32"}, {"step": 2, "values": 6114}),
+        (
+            "test.grib",
+            {"grid": [10, 10]},
+            {"grid": [10, 10], "area": [70, -20, 40, 40]},
+            {"latitude": 4, "longitude": 7},
+        ),
+    ],
+)
+def test_regrid_xarray_transposed_dims(sample, out_grid, out_grid_ref, dims):
+    ds_in = from_source("sample", sample).to_fieldlist()
+
+    ds = ds_in.to_xarray()
+    da = ds["2t"].transpose("longitude", "latitude", "values", "step", missing_dims="ignore")
+
+    r = regrid(da, out_grid=out_grid, interpolation="linear")  # transposed dims (non-contiguous array)
+    r_ref = regrid(ds["2t"], out_grid=out_grid, interpolation="linear")  # original dim order (reference)
+
+    compare_dims(r, dims, sizes=True)
+
+    assert r.earthkit.grid_spec == out_grid_ref
+    np.testing.assert_allclose(r.transpose(*r_ref.dims).values, r_ref.values)
+
+
+@pytest.mark.skipif(NO_MIR, reason="No mir available")
+@pytest.mark.skipif(NO_EKD, reason="No earthkit.data available")
+@pytest.mark.parametrize(
     "out_grid,out_grid_ref,dims",
     REFS,
 )


### PR DESCRIPTION
### Description

I'm trying to use earthkit-geo for a project where we load GRIB messages with earthkit-data, convert to xarray, and regrid with earthkit-geo's MIR backend. Due to upstream operations, the dimensions don't always end with `values` or `latitude, longitude` but get orders like `(forecast_issue_time, values, step)`.

Currently `xr_geo_dims` rejects these with "Dataset geography is not supported". We work around it by reordering dimensions before calling earthkit-geo, but I don't see a fundamental reason to require geo dims in trailing position: `apply_ufunc` already handles the reordering via `input_core_dims`, so this PR relaxes the check to accept `values` or `latitude`/`longitude` at any position.

While testing this I found a second, related issue: reordered dims mean `apply_ufunc`'s transpose can produce non-contiguous views, which `mir.ArrayInput` rejects (`PyArray_ISCARRAY_RO`). The PR therefore also forces C-contiguity in `MirBackend.regrid` before handing the array to mir. I think the copy is an acceptable price for accepting these inputs, and it only occurs for inputs that previously failed hard; for already-contiguous arrays it's a no-op returning the same object:

```python
import numpy as np
a = np.arange(12.0).reshape(3, 4)
assert np.ascontiguousarray(a) is a          # no copy
assert np.ascontiguousarray(a.T) is not a.T  # copy
```

## Proposed Changes
- `xr_geo_dims` detects geo dims by membership instead of position. `latitude`/`longitude` are returned in that fixed order so the raveled buffer has longitude varying fastest, matching the scan order mir expects from the gridspec. Datasets with both a `values` dim and lat/lon dims now raise an explicit error instead of silently picking `values`.
- `MirBackend.regrid` ensures C-contiguity before `mir.ArrayInput`.
- New test regridding transposed inputs (`values` and lat/lon paths), asserting numerical equality with the original, ordered result.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
