### PR TITLE
Ensure Xarray attributes are copied into result in regridding

### DIFF
--- a/src/earthkit/geo/grids/_regrid/data/xarray.py
+++ b/src/earthkit/geo/grids/_regrid/data/xarray.py
@@ -284,10 +284,13 @@ class XarrayDataHandler(DataHandler):
         if "_earthkit" in ds.attrs:
             has_earthkit = True
         else:
-            for var in ds.data_vars.values():
-                if "_earthkit" in var.attrs:
-                    has_earthkit = True
-                    break
+            import xarray as xr
+
+            if isinstance(ds, xr.Dataset):
+                for var in ds.data_vars.values():
+                    if "_earthkit" in var.attrs:
+                        has_earthkit = True
+                        break
 
         if has_earthkit:
             if hasattr(ds, "earthkit"):
@@ -371,6 +374,7 @@ class XarrayDataHandler(DataHandler):
                     "allow_rechunk": True,
                 },
                 output_dtypes=[da.dtype],
+                keep_attrs="identical",
             )
 
         if isinstance(values, xr.Dataset):


### PR DESCRIPTION
### Description

This PR fixes the issue when in `regrid()` the attributes were not copied into the resulting Xarray.  This caused `regrid()` to crash in Xarray version `2025.10.1`.

Fixes #92 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
